### PR TITLE
Use of custom handler factory

### DIFF
--- a/src/LoggerFactory.php
+++ b/src/LoggerFactory.php
@@ -9,11 +9,11 @@ class LoggerFactory
     public function __invoke(ContainerInterface $container) : Logger
     {
         $config = $container->get('config');
-
+        $handlersInConfig = $config['expressiveLogger']['handlers'] ?? [];
         $handlers = [];
 
         /* Get handlers object from factory */
-        foreach ($config['handlers'] as $name => $handler) {
+        foreach ($handlersInConfig as $name => $handler) {
             if ($container->has($handler['class'])) {
                 $handlers[$name] = $container->get($handler['class']);
             }

--- a/src/LoggerFactory.php
+++ b/src/LoggerFactory.php
@@ -3,14 +3,9 @@
 namespace ExpressiveLogger;
 
 use Interop\Container\ContainerInterface;
-use Monolog\Handler\RedisHandler;
 
 class LoggerFactory
 {
-    const NAMED_HANDLERS = [
-        'redis' => RedisHandler::class,
-    ];
-
     public function __invoke(ContainerInterface $container) : Logger
     {
         $config = $container->get('config');
@@ -18,9 +13,9 @@ class LoggerFactory
         $handlers = [];
 
         /* Get handlers object from factory */
-        foreach (self::NAMED_HANDLERS as $name => $handler) {
-            if ($container->has($handler)) {
-                $handlers[$name] = $container->get($handler);
+        foreach ($config['handlers'] as $name => $handler) {
+            if ($container->has($handler['class'])) {
+                $handlers[$name] = $container->get($handler['class']);
             }
         }
         


### PR DESCRIPTION
We check handler in container, if exists we use this instance. It allows us to use custom factories for handlers, add dependencies, etc.